### PR TITLE
Update Contribution Guidelines: Replace 'master' with 'main'

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -91,13 +91,13 @@ To maintain a consistent codebase, GPTRouter follows certain code style and codi
 
 If you have implemented a new feature, fixed a bug, or made any improvements, we welcome your pull requests. Before submitting a pull request, please make sure to do the following:
 
-1. Branch out from the latest `master`.
+1. Branch out from the latest `main`.
 
 2. Commit your changes with meaningful commit messages.
 
 3. Push your changes to your forked repository.
 
-4. Submit your pull request to the `master` branch of the main repository.
+4. Submit your pull request to the `main` branch of the main repository.
 
 We will review your changes and get back to you with feedback or merge it if everything looks good.
 


### PR DESCRIPTION
### Summary
This pull request updates the `CONTRIBUTING.md` file to replace references from `master` to `main`. The current documentation incorrectly mentions `master` as the branch to base pull requests on, which could cause confusion since the actual default branch of the repository is `main`.

### Rationale
- The repository's default branch is `main`, not `master`.
- Aligning the documentation with the current repository structure is crucial for avoiding confusion among new contributors.

### Changes Made
- Updated all instances where `master` was mentioned in the context of the default branch to `main` in the `CONTRIBUTING.md` file.

Thank you for considering this update. It aims to make the contribution process clearer and more straightforward for all contributors.
